### PR TITLE
Made Conditional Stronger | Had error fetching TopCoder

### DIFF
--- a/backend/route.py
+++ b/backend/route.py
@@ -120,7 +120,7 @@ def fetch_topcoder():
 
                 duration = get_duration(int(( mktime(end_time)-mktime(start_time) )/60 ))
                 name = item["summary"]
-                if "SRM" in name: url = "http://community.topcoder.com/tc?module=MatchDetails&rd="+ item["description"][110:115]
+                if "SRM" in name and "description" in item: url = "http://community.topcoder.com/tc?module=MatchDetails&rd="+ item["description"][110:115]
                 else :            url = "http://tco15.topcoder.com/algorithm/rules/"
                 
                 if cur_time<start_time:


### PR DESCRIPTION
The script was not able to fetch TopCoder. That is because SRM 673 didn't have the "description" key in its JSON. Right now, it looks like this (Note that description should be there after summary but it's not there). I found this by running your code locally through some modifications and catching the exception:

	{
	   "kind": "calendar#event",
	   "etag": "\"2892433196958000\"",
	   "id": "il1lmklqvamr66ka7p76v4cg5g",
	   "status": "confirmed",
	   "htmlLink": "https://www.google.com/calendar/event?eid=aWwxbG1rbHF2YW1yNjZrYTdwNzZ2NGNnNWcgYXBwaXJpby5jb21fYmhnYTNtdXNpdGF0ODVtaGRybmc5MDM1amdAZw&ctz=Asia/Calcutta",
	   "created": "2015-10-30T14:49:58.000Z",
	   "updated": "2015-10-30T14:49:58.479Z",
	   "summary": "SRM 673",
	   "creator": {
		"email": "tkirchner@appirio.com",
		"displayName": "Tim Kirchner"
	   },
	   "organizer": {
		"email": "appirio.com_bhga3musitat85mhdrng9035jg@group.calendar.google.com",
		"displayName": "topcoder Public Calendar",
		"self": true
	   },
	   "start": {
		"dateTime": "2015-11-18T21:30:00+05:30"
	   },
	   "end": {
		"dateTime": "2015-11-18T23:30:00+05:30"
	   },
	   "iCalUID": "il1lmklqvamr66ka7p76v4cg5g@google.com",
	   "sequence": 0
	  },

**What I have done** is simply checked if there is a "description" key in `item` by changing line 123.