### PR TITLE
Fix Topcoder scraper #34

### DIFF
--- a/backend/route.py
+++ b/backend/route.py
@@ -107,7 +107,7 @@ def fetch_codeforces():
 
 def fetch_topcoder():
     try:
-        page = urlopen("https://clients6.google.com/calendar/v3/calendars/appirio.com_bhga3musitat85mhdrng9035jg@group.calendar.google.com/events?calendarId=appirio.com_bhga3musitat85mhdrng9035jg%40group.calendar.google.com&singleEvents=true&timeZone=Asia%2FCalcutta&maxAttendees=1&maxResults=250&sanitizeHtml=true&timeMin=2015-04-26T00%3A00%3A00-04%3A00&timeMax=2016-06-07T00%3A00%3A00-04%3A00&key=AIzaSyBNlYH01_9Hc5S1J9vuFmu2nUqBZJNAXxs",timeout=15)
+        page = urlopen("https://clients6.google.com/calendar/v3/calendars/appirio.com_bhga3musitat85mhdrng9035jg@group.calendar.google.com/events?calendarId=appirio.com_bhga3musitat85mhdrng9035jg%40group.calendar.google.com&singleEvents=true&timeZone=Asia%2FCalcutta&maxAttendees=1&maxResults=250&sanitizeHtml=true&timeMin=2016-07-10T00%3A00%3A00-04%3A00&key=AIzaSyBNlYH01_9Hc5S1J9vuFmu2nUqBZJNAXxs",timeout=15)
         data = json.load(page)["items"]
         cur_time = localtime()
         for item in data:


### PR DESCRIPTION
Remove the optional maxTime parameter. 
The previous timeMax in url parameter is passed, so Topcoder events are not showing up anymore. 

https://developers.google.com/google-apps/calendar/v3/reference/events/list

Thanks!